### PR TITLE
nsh_parse.c: fix 'while' and 'until' loop condition

### DIFF
--- a/nshlib/nsh_parse.c
+++ b/nshlib/nsh_parse.c
@@ -1551,7 +1551,7 @@ static int nsh_loop(FAR struct nsh_vtbl_s *vtbl, FAR char **ppcmd,
 
           /* "Push" the old state and set the new state */
 
-          state  = whilematch == 0 ? NSH_LOOP_WHILE : NSH_LOOP_UNTIL;
+          state  = whilematch ? NSH_LOOP_WHILE : NSH_LOOP_UNTIL;
           enable = nsh_cmdenabled(vtbl);
 #ifdef NSH_DISABLE_SEMICOLON
           offset = np->np_foffs;


### PR DESCRIPTION
The loop condition logic was inverted:
  while true; do echo "test"; done
would exit immediately, while using 'until' would stay in the loop.
This is the opposite of how it is supposed to work.
The reason is that 'state' was set wrong because 'whilematch' is a bool.

cherry-picked from upstream (https://bitbucket.org/nuttx/apps/pull-requests/138/nsh_parsec-fix-while-and-until-loop/diff)